### PR TITLE
Added new field: DictField

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,7 @@ fields classes from :mod:`jsonmodels.fields`).
 
         name = fields.StringField(required=True)
         breed = fields.StringField()
+        extra = fields.DictField()
 
 
     class Dog(models.Base):

--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -146,6 +146,8 @@ class PrimitiveBuilder(Builder):
             obj_type = 'number'
         elif issubclass(self.type, float):
             obj_type = 'number'
+        elif issubclass(self.type, dict):
+            obj_type = 'object'
         else:
             raise errors.FieldNotSupported(
                 "Can't specify value schema!", self.type

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -180,11 +180,13 @@ class BoolField(BaseField):
         parsed = super(BoolField, self).parse_value(value)
         return bool(parsed) if parsed is not None else None
 
+
 class DictField(BaseField):
 
     """Dict field."""
 
     types = (dict, )
+
 
 class ListField(BaseField):
 

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -180,6 +180,11 @@ class BoolField(BaseField):
         parsed = super(BoolField, self).parse_value(value)
         return bool(parsed) if parsed is not None else None
 
+class DictField(BaseField):
+
+    """Dict field."""
+
+    types = (dict, )
 
 class ListField(BaseField):
 

--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -91,7 +91,7 @@ def _create_primitive_field_schema(field):
     elif isinstance(field, fields.BoolField):
         obj_type = 'boolean'
     elif isinstance(field, fields.DictField):
-        obj_type = 'dictionary'
+        obj_type = 'object'
     else:
         raise errors.FieldNotSupported(
             'Field {field} is not supported!'.format(

--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -90,6 +90,8 @@ def _create_primitive_field_schema(field):
         obj_type = 'float'
     elif isinstance(field, fields.BoolField):
         obj_type = 'boolean'
+    elif isinstance(field, fields.DictField):
+        obj_type = 'dictionary'
     else:
         raise errors.FieldNotSupported(
             'Field {field} is not supported!'.format(

--- a/tests/fixtures/schema1.json
+++ b/tests/fixtures/schema1.json
@@ -4,7 +4,7 @@
         "name": {"type": "string"},
         "surname": {"type": "string"},
         "age": {"type": "number"},
-        "extra": {"type": "dict"}
+        "extra": {"type": "object"}
     },
     "required": ["name", "surname"],
     "additionalProperties": false

--- a/tests/fixtures/schema1.json
+++ b/tests/fixtures/schema1.json
@@ -3,7 +3,8 @@
     "properties": {
         "name": {"type": "string"},
         "surname": {"type": "string"},
-        "age": {"type": "number"}
+        "age": {"type": "number"},
+        "extra": {"type": "dict"}
     },
     "required": ["name", "surname"],
     "additionalProperties": false

--- a/tests/fixtures/schema2.json
+++ b/tests/fixtures/schema2.json
@@ -9,7 +9,7 @@
             "properties": {
                 "brand": {"type": "string"},
                 "registration": {"type": "string"},
-                "extra": {"type": "dict"}
+                "extra": {"type": "object"}
             },
             "required": ["brand", "registration","extra"],
             "additionalProperties": false

--- a/tests/fixtures/schema2.json
+++ b/tests/fixtures/schema2.json
@@ -8,9 +8,10 @@
             "type": "object",
             "properties": {
                 "brand": {"type": "string"},
-                "registration": {"type": "string"}
+                "registration": {"type": "string"},
+                "extra": {"type": "dict"}
             },
-            "required": ["brand", "registration"],
+            "required": ["brand", "registration","extra"],
             "additionalProperties": false
         },
         "kids": {

--- a/tests/test_data_initialization.py
+++ b/tests/test_data_initialization.py
@@ -20,7 +20,7 @@ def test_initialization():
         surname='Wake',
         age=24,
         cash=2445.45,
-        extra_data={"location": "Oviedo, Spain", "gender": "Unknown"}
+        extra_data={"location": "Oviedo, Spain", "gender": "Unknown"},
         trash='123qwe',
     )
 
@@ -65,13 +65,13 @@ def test_deep_initialization():
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
-        assert car.extra = {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
+        assert car.extra == {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
 
         assert parking.location == 'somewhere'
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
-        assert car.extra = {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
+        assert car.extra == {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
 
 
 def test_deep_initialization_error_with_multitypes():

--- a/tests/test_data_initialization.py
+++ b/tests/test_data_initialization.py
@@ -13,12 +13,14 @@ def test_initialization():
         surname = fields.StringField()
         age = fields.IntField()
         cash = fields.FloatField()
+        extra_data = fields.DictField()
 
     data = dict(
         name='Alan',
         surname='Wake',
         age=24,
         cash=2445.45,
+        extra_data={"location": "Oviedo, Spain", "gender": "Unknown"}
         trash='123qwe',
     )
 
@@ -30,6 +32,7 @@ def test_initialization():
         assert alan.surname == 'Wake'
         assert alan.age == 24
         assert alan.cash == 2445.45
+        assert alan.extra_data == {"location": "Oviedo, Spain", "gender": "Unknown"}
 
         assert not hasattr(alan, 'trash')
 
@@ -39,6 +42,7 @@ def test_deep_initialization():
     class Car(models.Base):
 
         brand = fields.StringField()
+        extra = fields.DictField()
 
     class ParkingPlace(models.Base):
 
@@ -48,7 +52,8 @@ def test_deep_initialization():
     data = {
         'location': 'somewhere',
         'car': {
-            'brand': 'awesome brand'
+            'brand': 'awesome brand',
+            'extra': {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
         }
     }
 
@@ -60,11 +65,13 @@ def test_deep_initialization():
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
+        assert car.extra = {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
 
         assert parking.location == 'somewhere'
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
+        assert car.extra = {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
 
 
 def test_deep_initialization_error_with_multitypes():

--- a/tests/test_data_initialization.py
+++ b/tests/test_data_initialization.py
@@ -32,7 +32,8 @@ def test_initialization():
         assert alan.surname == 'Wake'
         assert alan.age == 24
         assert alan.cash == 2445.45
-        assert alan.extra_data == {"location": "Oviedo, Spain", "gender": "Unknown"}
+        assert alan.extra_data == {"location": "Oviedo, Spain",
+                                   "gender": "Unknown"}
 
         assert not hasattr(alan, 'trash')
 
@@ -53,7 +54,9 @@ def test_deep_initialization():
         'location': 'somewhere',
         'car': {
             'brand': 'awesome brand',
-            'extra': {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
+            'extra': {"extra_int": 1, "extra_str": "a",
+                      "extra_bool": True,
+                      "extra_dict": {"I am extra": True}}
         }
     }
 
@@ -65,13 +68,17 @@ def test_deep_initialization():
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
-        assert car.extra == {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
+        assert car.extra == {"extra_int": 1, "extra_str": "a",
+                             "extra_bool": True,
+                             "extra_dict": {"I am extra": True}}
 
         assert parking.location == 'somewhere'
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
-        assert car.extra == {"extra_int": 1, "extra_str": "a", "extra_bool": True, "extra_dict": {"I am extra": True}}
+        assert car.extra == {"extra_int": 1, "extra_str": "a",
+                             "extra_bool": True,
+                             "extra_dict": {"I am extra": True}}
 
 
 def test_deep_initialization_error_with_multitypes():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -39,24 +39,13 @@ def test_dict_field():
         extra = field
         extra_required = fields.DictField(required=True)
         extra_default = fields.DictField(default={"extra_default":"Hello", "deep_extra": {"spanish": "Hola"}}, validators=[validators.Length(2)])
-        extra_nullable = field.DictField(nullable=True)
+        extra_nullable = fields.DictField(nullable=True)
 
-    person = Person()
-    assert person.is_programmer is None
+    person = Person(extra_required={"required": True})
+    assert person.extra is None
+    assert person.extra_required == {"required": True}
+    assert person.extra_default == {"extra_default":"Hello", "deep_extra": {"spanish": "Hola"}}
 
-    person.is_programmer = True
-    assert person.is_programmer is True
+    person.extra = {"extra":True}
+    assert person.extra == {"extra":True}
 
-    person.is_programmer = False
-    assert person.is_programmer is False
-
-    assert field.parse_value(True) is True
-    assert field.parse_value('something') is True
-    assert field.parse_value(object()) is True
-
-    assert field.parse_value(None) is None
-
-    assert field.parse_value(False) is False
-    assert field.parse_value(0) is False
-    assert field.parse_value('') is False
-    assert field.parse_value([]) is False

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -33,19 +33,23 @@ def test_bool_field():
 def test_dict_field():
 
     field = fields.DictField()
+    default_field = fields.DictField(default={
+        "extra_default": "Hello",
+        "deep_extra": {"spanish": "Hola"}},
+        validators=[validators.Length(2)])
 
     class Person(models.Base):
 
         extra = field
         extra_required = fields.DictField(required=True)
-        extra_default = fields.DictField(default={"extra_default":"Hello", "deep_extra": {"spanish": "Hola"}}, validators=[validators.Length(2)])
+        extra_default = default_field
         extra_nullable = fields.DictField(nullable=True)
 
     person = Person(extra_required={"required": True})
     assert person.extra is None
     assert person.extra_required == {"required": True}
-    assert person.extra_default == {"extra_default":"Hello", "deep_extra": {"spanish": "Hola"}}
+    assert person.extra_default == {"extra_default": "Hello",
+                                    "deep_extra": {"spanish": "Hola"}}
 
-    person.extra = {"extra":True}
-    assert person.extra == {"extra":True}
-
+    person.extra = {"extra": True}
+    assert person.extra == {"extra": True}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,4 @@
-from jsonmodels import models, fields
+from jsonmodels import models, fields, validators
 
 
 def test_bool_field():
@@ -8,6 +8,38 @@ def test_bool_field():
     class Person(models.Base):
 
         is_programmer = field
+
+    person = Person()
+    assert person.is_programmer is None
+
+    person.is_programmer = True
+    assert person.is_programmer is True
+
+    person.is_programmer = False
+    assert person.is_programmer is False
+
+    assert field.parse_value(True) is True
+    assert field.parse_value('something') is True
+    assert field.parse_value(object()) is True
+
+    assert field.parse_value(None) is None
+
+    assert field.parse_value(False) is False
+    assert field.parse_value(0) is False
+    assert field.parse_value('') is False
+    assert field.parse_value([]) is False
+
+
+def test_dict_field():
+
+    field = fields.DictField()
+
+    class Person(models.Base):
+
+        extra = field
+        extra_required = fields.DictField(required=True)
+        extra_default = fields.DictField(default={"extra_default":"Hello", "deep_extra": {"spanish": "Hola"}}, validators=[validators.Length(2)])
+        extra_nullable = field.DictField(nullable=True)
 
     person = Person()
     assert person.is_programmer is None

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -17,7 +17,7 @@ def test_model1():
     alan.name = 'Alan'
     alan.surname = 'Wake'
     alan.age = 34
-    alan.extra = {"extra_value":1}
+    alan.extra = {"extra_value": 1}
 
 
 def test_required():

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -10,12 +10,14 @@ def test_model1():
         name = fields.StringField()
         surname = fields.StringField()
         age = fields.IntField()
+        extra = fields.DictField()
 
     alan = Person()
 
     alan.name = 'Alan'
     alan.surname = 'Wake'
     alan.age = 34
+    alan.extra = {"extra_value":1}
 
 
 def test_required():

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -1,14 +1,15 @@
-from jsonmodels.fields import StringField, ListField, EmbeddedField
+from jsonmodels.fields import StringField, DictField, ListField, EmbeddedField
 from jsonmodels.models import Base
 
 
 class Nullable(Base):
     field = StringField(nullable=True)
 
+class NullableDict(Base):
+    field = DictField(nullable=True)
 
 class NullableListField(Base):
     field = ListField([str], nullable=True)
-
 
 class NullableEmbedded(Base):
     field = EmbeddedField(Nullable, nullable=True)
@@ -19,6 +20,10 @@ def test_nullable_simple_field():
 
     assert result['properties']['field']['type'] == ['string', 'null']
 
+def test_nullable_dict_field():
+    result = NullableDict.to_json_schema()
+
+    assert result['properties']['field']['type'] == ['dict', 'null']
 
 def test_nullable_list_field():
     result = NullableListField.to_json_schema()

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -23,7 +23,7 @@ def test_nullable_simple_field():
 def test_nullable_dict_field():
     result = NullableDict.to_json_schema()
 
-    assert result['properties']['field']['type'] == ['dict', 'null']
+    assert result['properties']['field']['type'] == ['object', 'null']
 
 def test_nullable_list_field():
     result = NullableListField.to_json_schema()

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -5,11 +5,14 @@ from jsonmodels.models import Base
 class Nullable(Base):
     field = StringField(nullable=True)
 
+
 class NullableDict(Base):
     field = DictField(nullable=True)
 
+
 class NullableListField(Base):
     field = ListField([str], nullable=True)
+
 
 class NullableEmbedded(Base):
     field = EmbeddedField(Nullable, nullable=True)
@@ -20,10 +23,12 @@ def test_nullable_simple_field():
 
     assert result['properties']['field']['type'] == ['string', 'null']
 
+
 def test_nullable_dict_field():
     result = NullableDict.to_json_schema()
 
     assert result['properties']['field']['type'] == ['object', 'null']
+
 
 def test_nullable_list_field():
     result = NullableListField.to_json_schema()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -408,12 +408,15 @@ def test_primitives():
         (str, "string"),
         (bool, "boolean"),
         (int, "number"),
-        (float, "number")
+        (float, "number"),
+        (dict, "object")
     )
     for pytpe, jstype in cases:
         b = builders.PrimitiveBuilder(pytpe)
         assert b.build() == {"type": jstype}
         b = builders.PrimitiveBuilder(pytpe, nullable=True)
         assert b.build() == {"type": [jstype, "null"]}
+        b = builders.PrimitiveBuilder(pytpe, nullable=True, default=0)
+        assert b.build() == {"type": [jstype, "null"], "default": 0}
         b = builders.PrimitiveBuilder(pytpe, nullable=True, default=0)
         assert b.build() == {"type": [jstype, "null"], "default": 0}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,6 +13,7 @@ def test_model1():
         name = fields.StringField(required=True)
         surname = fields.StringField(required=True)
         age = fields.IntField()
+        extra = fields.DictField()
 
     alan = Person()
     schema = alan.to_json_schema()
@@ -27,6 +28,7 @@ def test_model2():
 
         brand = fields.StringField(required=True)
         registration = fields.StringField(required=True)
+        extra = fields.DictField(required=True)
 
     class Toy(models.Base):
 
@@ -101,6 +103,7 @@ def test_model_with_constructors():
     class Car(models.Base):
         brand = fields.StringField(required=True)
         registration = fields.StringField(required=True)
+        extra = fields.DictField(required=True)
 
         def __init__(self, some_value):
             pass

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -30,14 +30,14 @@ def test_to_struct_basic():
 
     alan.age = 24
     alan.cash = 2445.45
-    alan.extra = {"extra_value":1}
+    alan.extra = {"extra_value": 1}
 
     pattern = {
         'name': 'Alan',
         'surname': 'Wake',
         'age': 24,
         'cash': 2445.45,
-        'extra' : {"extra_value":1}
+        'extra': {"extra_value": 1}
     }
 
     assert pattern == alan.to_struct()
@@ -68,9 +68,9 @@ def test_to_struct_nested_1():
     assert pattern == place.to_struct()
 
     place.car.brand = 'Fiat'
-    place.car.extra = {"extra":1}
+    place.car.extra = {"extra": 1}
     pattern['car']['brand'] = 'Fiat'
-    pattern['car']['extra'] = {"extra":1}
+    pattern['car']['extra'] = {"extra": 1}
     assert pattern == place.to_struct()
 
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -18,6 +18,7 @@ def test_to_struct_basic():
         surname = fields.StringField(required=True)
         age = fields.IntField()
         cash = fields.FloatField()
+        extra = fields.DictField()
 
     alan = Person()
     with pytest.raises(errors.ValidationError):
@@ -29,12 +30,14 @@ def test_to_struct_basic():
 
     alan.age = 24
     alan.cash = 2445.45
+    alan.extra = {"extra_value":1}
 
     pattern = {
         'name': 'Alan',
         'surname': 'Wake',
         'age': 24,
         'cash': 2445.45,
+        'extra' : {"extra_value":1}
     }
 
     assert pattern == alan.to_struct()
@@ -45,6 +48,7 @@ def test_to_struct_nested_1():
     class Car(models.Base):
 
         brand = fields.StringField()
+        extra = fields.DictField()
 
     class ParkingPlace(models.Base):
 
@@ -64,7 +68,9 @@ def test_to_struct_nested_1():
     assert pattern == place.to_struct()
 
     place.car.brand = 'Fiat'
+    place.car.extra = {"extra":1}
     pattern['car']['brand'] = 'Fiat'
+    pattern['car']['extra'] = {"extra":1}
     assert pattern == place.to_struct()
 
 


### PR DESCRIPTION
The new field allows storing a dictionary without having to be constrained to a given schema.
The schema type is "object", according to JSON schema

My use case and why I implemented and tested this:

I am creating some new models in my project and we usually save some fields that need to be store for extra purposes but it doesn't' make sense to create a field for each of these fields. In my case for a video/audio codec handler.

It has been tested and I also added an example of the field in the documentation.

Thanks for the effort in creating this cool library, if there is any issue let me know.

@beregond please take a look and if possible let me know once it will be published into pip so I can update my project.
Thansk